### PR TITLE
Update to vuetify v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ pnpm-debug.log*
 .direnv
 result
 result-*
+
+config.json

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,5 +13,13 @@ export default [
       "prettier/prettier": "error",
     },
   },
+
+  {
+    rules: {
+      "vuetify/no-deprecated-components": "error",
+      "vuetify/no-deprecated-props": "error",
+    },
+  },
+
   eslintConfigPrettierFlat,
 ];

--- a/package.json
+++ b/package.json
@@ -1,50 +1,20 @@
 {
-  "name": "website-vue",
-  "private": true,
-  "type": "module",
-  "version": "0.0.0",
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint . --fix"
-  },
-  "dependencies": {
-    "@fontsource/roboto": "5.2.10",
-    "@mdi/font": "7.4.47",
-    "pinia": "^3.0.4",
-    "vue": "^3.5.32",
-    "vuetify": "^4.0.5"
-  },
-  "devDependencies": {
-    "@fortawesome/fontawesome-free": "^7.2.0",
-    "@mdi/js": "^7.4.47",
-    "@vitejs/plugin-vue": "^6.0.5",
-    "eslint": "^10.2.0",
-    "eslint-config-prettier": "^10.1.8",
-    "eslint-config-vuetify": "^4.5.0",
-    "eslint-plugin-prettier": "^5.5.5",
-    "eslint-plugin-vuetify": "^2.7.2",
-    "prettier": "^3.8.1",
-    "sass-embedded": "^1.99.0",
-    "unplugin-auto-import": "^21.0.0",
-    "unplugin-fonts": "^2.0.0",
-    "unplugin-vue-components": "^32.0.0",
-    "vite": "^8.0.6",
-    "vite-plugin-vue-layouts-next": "^2.1.0",
-    "vue-router": "^5.0.4"
-  },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "onFail": "error"
+    "name": "website-vue",
+    "private": true,
+    "type": "module",
+    "version": "0.0.0",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "lint": "eslint . --fix"
     },
     "dependencies": {
         "@fontsource/roboto": "5.2.10",
         "@mdi/font": "7.4.47",
         "pinia": "^3.0.4",
         "vue": "^3.5.32",
-        "vuetify": "^3.12.5"
+        "vuetify": "^4.0.5"
     },
     "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",
@@ -54,6 +24,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-config-vuetify": "^4.5.0",
         "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-vuetify": "^2.7.2",
         "prettier": "^3.8.1",
         "sass-embedded": "^1.99.0",
         "unplugin-auto-import": "^21.0.0",
@@ -61,7 +32,6 @@
         "unplugin-vue-components": "^32.0.0",
         "vite": "^8.0.6",
         "vite-plugin-vue-layouts-next": "^2.1.0",
-        "vite-plugin-vuetify": "^2.1.3",
         "vue-router": "^5.0.4"
     },
     "devEngines": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
         "unplugin-auto-import": "^21.0.0",
         "unplugin-fonts": "^2.0.0",
         "unplugin-vue-components": "^32.0.0",
-        "vite": "^8.0.6",
+        "vite": "^8.0.7",
         "vite-plugin-vue-layouts-next": "^2.1.0",
+        "vite-plugin-vuetify": "^2.1.3",
         "vue-router": "^5.0.4"
     },
     "devEngines": {

--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "website-vue",
-    "private": true,
-    "type": "module",
-    "version": "0.0.0",
-    "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "preview": "vite preview",
-        "lint": "eslint . --fix"
+  "name": "website-vue",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --fix"
+  },
+  "dependencies": {
+    "@fontsource/roboto": "5.2.10",
+    "@mdi/font": "7.4.47",
+    "pinia": "^3.0.4",
+    "vue": "^3.5.32",
+    "vuetify": "^4.0.5"
+  },
+  "devDependencies": {
+    "@fortawesome/fontawesome-free": "^7.2.0",
+    "@mdi/js": "^7.4.47",
+    "@vitejs/plugin-vue": "^6.0.5",
+    "eslint": "^10.2.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-config-vuetify": "^4.5.0",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-vuetify": "^2.7.2",
+    "prettier": "^3.8.1",
+    "sass-embedded": "^1.99.0",
+    "unplugin-auto-import": "^21.0.0",
+    "unplugin-fonts": "^2.0.0",
+    "unplugin-vue-components": "^32.0.0",
+    "vite": "^8.0.6",
+    "vite-plugin-vue-layouts-next": "^2.1.0",
+    "vue-router": "^5.0.4"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "onFail": "error"
     },
-    "dependencies": {
-        "@fontsource/roboto": "5.2.10",
-        "@mdi/font": "7.4.47",
-        "pinia": "^3.0.4",
-        "vue": "^3.5.32",
-        "vuetify": "^3.12.5"
-    },
-    "devDependencies": {
-        "@fortawesome/fontawesome-free": "^7.2.0",
-        "@mdi/js": "^7.4.47",
-        "@vitejs/plugin-vue": "^6.0.5",
-        "eslint": "^10.2.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-config-vuetify": "^4.5.0",
-        "eslint-plugin-prettier": "^5.5.5",
-        "prettier": "^3.8.1",
-        "sass-embedded": "^1.99.0",
-        "unplugin-auto-import": "^21.0.0",
-        "unplugin-fonts": "^2.0.0",
-        "unplugin-vue-components": "^32.0.0",
-        "vite": "^8.0.6",
-        "vite-plugin-vue-layouts-next": "^2.1.0",
-        "vite-plugin-vuetify": "^2.1.3",
-        "vue-router": "^5.0.4"
-    },
-    "devEngines": {
-        "runtime": {
-            "name": "node",
-            "onFail": "error"
-        },
-        "packageManager": {
-            "name": "pnpm",
-            "onFail": "error"
-        }
-    },
-    "packageManager": "pnpm@10.33.0"
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
+  },
+  "packageManager": "pnpm@10.33.0"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "prettier": "^3.8.1",
         "sass-embedded": "^1.99.0",
         "unplugin-auto-import": "^21.0.0",
-        "unplugin-fonts": "^1.4.0",
+        "unplugin-fonts": "^2.0.0",
         "unplugin-vue-components": "^32.0.0",
         "vite": "^8.0.6",
         "vite-plugin-vue-layouts-next": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 7.4.47
       '@vitejs/plugin-vue':
         specifier: ^6.0.5
-        version: 6.0.5(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
+        version: 6.0.5(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
       eslint:
         specifier: ^10.2.0
         version: 10.2.0
@@ -59,16 +59,19 @@ importers:
         version: 21.0.0
       unplugin-fonts:
         specifier: ^2.0.0
-        version: 2.0.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))
       unplugin-vue-components:
         specifier: ^32.0.0
         version: 32.0.0(vue@3.5.32(typescript@6.0.2))
       vite:
-        specifier: ^8.0.6
-        version: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
+        specifier: ^8.0.7
+        version: 8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
       vite-plugin-vue-layouts-next:
         specifier: ^2.1.0
-        version: 2.1.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
+        version: 2.1.0(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
+      vite-plugin-vuetify:
+        specifier: ^2.1.3
+        version: 2.1.3(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)
       vue-router:
         specifier: ^5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
@@ -1768,8 +1771,8 @@ packages:
       vue: ^3.0.0
       vuetify: '>=3'
 
-  vite@8.0.6:
-    resolution: {integrity: sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==}
+  vite@8.0.7:
+    resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2287,10 +2290,10 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@6.0.5(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
+  '@vitejs/plugin-vue@6.0.5(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@6.0.2)
 
   '@vue-macros/common@3.1.2(vue@3.5.32(typescript@6.0.2))':
@@ -2393,7 +2396,6 @@ snapshots:
       upath: 2.0.1
       vue: 3.5.32(typescript@6.0.2)
       vuetify: 4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
-    optional: true
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -3452,7 +3454,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
 
-  unplugin-fonts@2.0.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)):
+  unplugin-fonts@2.0.0(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)):
     dependencies:
       css-tree: 3.2.1
       fast-glob: 3.3.3
@@ -3460,7 +3462,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
       unplugin: 3.0.0
-      vite: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
 
   unplugin-utils@0.3.1:
     dependencies:
@@ -3493,8 +3495,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  upath@2.0.1:
-    optional: true
+  upath@2.0.1: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -3510,29 +3511,28 @@ snapshots:
 
   varint@6.0.0: {}
 
-  vite-plugin-vue-layouts-next@2.1.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)):
+  vite-plugin-vue-layouts-next@2.1.0(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)):
     dependencies:
       debug: 4.4.3
       fast-glob: 3.3.3
-      vite: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@6.0.2)
       vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vuetify@2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5):
+  vite-plugin-vuetify@2.1.3(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5):
     dependencies:
       '@vuetify/loader-shared': 2.1.2(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)
       debug: 4.4.3
       upath: 2.0.1
-      vite: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
+      vite: 8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@6.0.2)
       vuetify: 4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3):
+  vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3596,7 +3596,7 @@ snapshots:
       vue: 3.5.32(typescript@6.0.2)
     optionalDependencies:
       typescript: 6.0.2
-      vite-plugin-vuetify: 2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)
+      vite-plugin-vuetify: 2.1.3(vite@8.0.7(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)
 
   webpack-virtual-modules@0.6.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.5.32
         version: 3.5.32(typescript@6.0.2)
       vuetify:
-        specifier: ^3.12.5
-        version: 3.12.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
+        specifier: ^4.0.5
+        version: 4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
     devDependencies:
       '@fortawesome/fontawesome-free':
         specifier: ^7.2.0
@@ -45,6 +45,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0))(eslint@10.2.0)(prettier@3.8.1)
+      eslint-plugin-vuetify:
+        specifier: ^2.7.2
+        version: 2.7.2(@stylistic/eslint-plugin@5.10.0(eslint@10.2.0))(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(vue-eslint-parser@10.4.0(eslint@10.2.0))(vuetify@4.0.5)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -66,9 +69,6 @@ importers:
       vite-plugin-vue-layouts-next:
         specifier: ^2.1.0
         version: 2.1.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
-      vite-plugin-vuetify:
-        specifier: ^2.1.3
-        version: 2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@3.12.5)
       vue-router:
         specifier: ^5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)))(vue@3.5.32(typescript@6.0.2))
@@ -879,6 +879,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-vuetify@2.7.2:
+    resolution: {integrity: sha512-c8uKnb4DFJFBaqGTKT9Yv6SDhe+cVAQpRpey7nRlpXgXfHpMEe8u6yg5DEhn+Diam0bY05nEe3+T/t/d+cEinQ==}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
+      vuetify: ^3.0.0 || ^4.0.0
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1425,6 +1431,10 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  requireindex@1.2.0:
+    resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
+    engines: {node: '>=0.10.5'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1830,8 +1840,8 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.12.5:
-    resolution: {integrity: sha512-Gk3eDIiBXpv+QjMTYmXXk/uvpqaSNAgprcV/Og0btBUx4saLN7AUmqUi34hRmBqu2tpype2GVvg2yxJUqP2mdg==}
+  vuetify@4.0.5:
+    resolution: {integrity: sha512-pFysKOHuY3dROTVh9PdlhVz50ZR0E5/goY5ecTXc8F8tajUA2ee3xZ8Lqs1WtEw/X3w93wx/LogyjgaQCAL/Ig==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
@@ -2378,11 +2388,12 @@ snapshots:
 
   '@vue/shared@3.5.32': {}
 
-  '@vuetify/loader-shared@2.1.2(vue@3.5.32(typescript@6.0.2))(vuetify@3.12.5)':
+  '@vuetify/loader-shared@2.1.2(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)':
     dependencies:
       upath: 2.0.1
       vue: 3.5.32(typescript@6.0.2)
-      vuetify: 3.12.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
+      vuetify: 4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
+    optional: true
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2678,6 +2689,17 @@ snapshots:
     optionalDependencies:
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.2.0)
       '@typescript-eslint/parser': 8.58.0(eslint@10.2.0)(typescript@6.0.2)
+
+  eslint-plugin-vuetify@2.7.2(@stylistic/eslint-plugin@5.10.0(eslint@10.2.0))(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(vue-eslint-parser@10.4.0(eslint@10.2.0))(vuetify@4.0.5):
+    dependencies:
+      eslint: 10.2.0
+      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@10.2.0))(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(vue-eslint-parser@10.4.0(eslint@10.2.0))
+      requireindex: 1.2.0
+      vuetify: 4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
+    transitivePeerDependencies:
+      - '@stylistic/eslint-plugin'
+      - '@typescript-eslint/parser'
+      - vue-eslint-parser
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3183,6 +3205,8 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  requireindex@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   reusify@1.1.0: {}
@@ -3469,7 +3493,8 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  upath@2.0.1: {}
+  upath@2.0.1:
+    optional: true
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -3495,16 +3520,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vuetify@2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@3.12.5):
+  vite-plugin-vuetify@2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5):
     dependencies:
-      '@vuetify/loader-shared': 2.1.2(vue@3.5.32(typescript@6.0.2))(vuetify@3.12.5)
+      '@vuetify/loader-shared': 2.1.2(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)
       debug: 4.4.3
       upath: 2.0.1
       vite: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@6.0.2)
-      vuetify: 3.12.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
+      vuetify: 4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2))
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3):
     dependencies:
@@ -3565,12 +3591,12 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
 
-  vuetify@3.12.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2)):
+  vuetify@4.0.5(typescript@6.0.2)(vite-plugin-vuetify@2.1.3)(vue@3.5.32(typescript@6.0.2)):
     dependencies:
       vue: 3.5.32(typescript@6.0.2)
     optionalDependencies:
       typescript: 6.0.2
-      vite-plugin-vuetify: 2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@3.12.5)
+      vite-plugin-vuetify: 2.1.3(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))(vuetify@4.0.5)
 
   webpack-virtual-modules@0.6.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^21.0.0
         version: 21.0.0
       unplugin-fonts:
-        specifier: ^1.4.0
-        version: 1.4.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))
+        specifier: ^2.0.0
+        version: 2.0.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))
       unplugin-vue-components:
         specifier: ^32.0.0
         version: 32.0.0(vue@3.5.32(typescript@6.0.2))
@@ -104,6 +104,10 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@capsizecss/unpack@4.0.0':
+    resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
+    engines: {node: '>=18'}
 
   '@clack/core@1.2.0':
     resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
@@ -695,6 +699,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -999,6 +1007,14 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fontaine@0.8.0:
+    resolution: {integrity: sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==}
+    engines: {node: '>=18.12.0'}
+
+  fontkitten@1.0.3:
+    resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
+    engines: {node: '>=20'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1213,12 +1229,18 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
+
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
     engines: {node: '>=20.19.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1609,6 +1631,9 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -1633,6 +1658,9 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
   typescript-eslint@8.58.0:
     resolution: {integrity: sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==}
@@ -1665,11 +1693,11 @@ packages:
       '@vueuse/core':
         optional: true
 
-  unplugin-fonts@1.4.0:
-    resolution: {integrity: sha512-TIJqr5rSlK/+3oL5nnrrEJ+Ty2taQ/bTJY1C5abYnksl553Q3HoHVqS4pnRLDkwpZq8AYqywib3kEVvHH+CtRQ==}
+  unplugin-fonts@2.0.0:
+    resolution: {integrity: sha512-MjyPgq9UVXYSQlcqG5Y/tYFCJvK0unURtT8+PdhrYV7u/8uwycqqLj5ouwpZ+oNQXRvemYqgnSLxGUv00r984g==}
     peerDependencies:
       '@nuxt/kit': ^3.0.0 || ^4.0.0
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
@@ -1690,10 +1718,6 @@ packages:
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
-    engines: {node: '>=18.12.0'}
-
-  unplugin@2.3.5:
-    resolution: {integrity: sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==}
     engines: {node: '>=18.12.0'}
 
   unplugin@3.0.0:
@@ -1879,6 +1903,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bufbuild/protobuf@2.11.0': {}
+
+  '@capsizecss/unpack@4.0.0':
+    dependencies:
+      fontkitten: 1.0.3
 
   '@clack/core@1.2.0':
     dependencies:
@@ -2461,6 +2489,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -2794,6 +2827,20 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fontaine@0.8.0:
+    dependencies:
+      '@capsizecss/unpack': 4.0.0
+      css-tree: 3.2.1
+      magic-regexp: 0.10.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      ufo: 1.6.3
+      unplugin: 2.3.11
+
+  fontkitten@1.0.3:
+    dependencies:
+      tiny-inflate: 1.0.3
+
   fsevents@2.3.3:
     optional: true
 
@@ -2954,6 +3001,16 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.3
+      unplugin: 2.3.11
+
   magic-string-ast@1.0.3:
     dependencies:
       magic-string: 0.30.21
@@ -2961,6 +3018,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -3303,6 +3362,8 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tiny-inflate@1.0.3: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
@@ -3323,6 +3384,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-level-regexp@0.1.17: {}
 
   typescript-eslint@8.58.0(eslint@10.2.0)(typescript@6.0.2):
     dependencies:
@@ -3365,10 +3428,14 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
 
-  unplugin-fonts@1.4.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)):
+  unplugin-fonts@2.0.0(vite@8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)):
     dependencies:
+      css-tree: 3.2.1
       fast-glob: 3.3.3
-      unplugin: 2.3.5
+      fontaine: 0.8.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      unplugin: 3.0.0
       vite: 8.0.6(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3)
 
   unplugin-utils@0.3.1:
@@ -3392,12 +3459,6 @@ snapshots:
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      acorn: 8.16.0
-      picomatch: 4.0.4
-      webpack-virtual-modules: 0.6.2
-
-  unplugin@2.3.5:
-    dependencies:
       acorn: 8.16.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2

--- a/src/components/AppFeatures.vue
+++ b/src/components/AppFeatures.vue
@@ -11,7 +11,7 @@
         <v-list-item variant="text">
           <v-list-item-title>
             <v-avatar class="mb-2 bg-primary" :icon="item.icon" />
-            <p class="text-body-2 font-weight-bold text-truncate pb-1">
+            <p class="text-body-medium font-weight-bold text-truncate pb-1">
               {{ item.title }}
             </p>
           </v-list-item-title>

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -6,7 +6,7 @@
         cols="12"
         sm="6"
       >
-        <p class="text-caption">
+        <p class="text-body-small">
           © {{ new Date().getFullYear() }} Zyner. All rights reserved.
         </p>
       </v-col>

--- a/src/components/AppHero.vue
+++ b/src/components/AppHero.vue
@@ -11,11 +11,11 @@
           >
             <template #append></template>
           </v-chip>
-          <p class="text-h4 text-md-h3 font-weight-bold mb-6">
+          <p class="text-headline-large text-md-h3 font-weight-bold mb-6">
             Digital labbmiljö till ett fast medlemspris
           </p>
 
-          <p class="text-body-1 text-medium-emphasis mb-10">
+          <p class="text-body-large text-medium-emphasis mb-10">
             Vi drivs utan vinstintresse och levererar trygga och hållbara
             lösningar för ideella föreningar och privatpersoner.
           </p>

--- a/src/components/AppPartners.vue
+++ b/src/components/AppPartners.vue
@@ -9,7 +9,7 @@
             </v-avatar>
           </template>
           <template #title>
-            <span class="text-body-1 font-weight-bold text-truncate">
+            <span class="text-body-large font-weight-bold text-truncate">
               {{ partner.title }}
             </span>
           </template>

--- a/src/components/AppSection.vue
+++ b/src/components/AppSection.vue
@@ -1,12 +1,12 @@
 <template>
   <v-container>
     <v-responsive class="text-center mx-auto" max-width="600">
-      <p v-if="caption" class="mt-8 text-overline">{{ caption }}</p>
+      <p v-if="caption" class="mt-8 text-label-medium text-uppercase">{{ caption }}</p>
 
-      <p v-if="title" class="font-weight-bold text-h4">{{ title }}</p>
+      <p v-if="title" class="font-weight-bold text-headline-large">{{ title }}</p>
       <p
         v-if="subtitle"
-        class="mt-2 text-subtitle-1 text-medium-emphasis hidden-sm-and-down"
+        class="mt-2 text-body-large text-medium-emphasis hidden-sm-and-down"
       >
         {{ subtitle }}
       </p>

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,5 +1,4 @@
 import { createVuetify } from "vuetify";
-import { md3 } from "vuetify/blueprints";
 import { fa } from "vuetify/iconsets/fa";
 import { aliases, mdi } from "vuetify/iconsets/mdi-svg";
 import "vuetify/styles";
@@ -7,8 +6,6 @@ import "@fortawesome/fontawesome-free/css/all.css";
 import "@mdi/font/css/materialdesignicons.css";
 
 export default createVuetify({
-  ssr: true,
-  blueprint: md3,
   theme: {
     defaultTheme: "system",
   },

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -8,3 +8,8 @@
 // @use 'vuetify/settings' with (
 //   $color-pack: false
 // );
+
+p {
+    margin-block-start: .5em;
+    margin-block-end: .5em;
+}


### PR DESCRIPTION
The major change in v4 is the new md3 design. This means that buttons, titles and etc. Look different.

## Current:

<img width="1726" height="995" alt="image" src="https://github.com/user-attachments/assets/cf8b5979-835f-4e50-94cb-008d42845b67" />

## Updated:

<img width="1725" height="990" alt="image" src="https://github.com/user-attachments/assets/65d964dc-cf28-4e4b-ae38-bc4c337d504a" />

Please note the text- utility classes have been changed and i've only updated them according to https://vuetifyjs.com/en/getting-started/typography-migration/

As stated in the article above 

"Large headings (h1-h3): MD3 display variants are significantly smaller than MD2 headings. Consider customizing these sizes if maintaining visual hierarchy is critical."

But I do not see the need to do this for our website.
