### PR TITLE
chore: fix eslint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,27 @@
+import tsParser from "@typescript-eslint/parser";
 import eslintConfigPrettierFlat from "eslint-config-prettier/flat";
 import vuetify from "eslint-config-vuetify";
 import pluginPrettier from "eslint-plugin-prettier";
+import pluginVuetify from "eslint-plugin-vuetify";
 
 export default [
   ...(await vuetify()),
+
+  {
+    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+    languageOptions: {
+      parser: tsParser,
+    },
+  },
+
+  {
+    files: ["**/*.vue"],
+    languageOptions: {
+      parserOptions: {
+        parser: tsParser,
+      },
+    },
+  },
 
   {
     plugins: {
@@ -15,6 +33,9 @@ export default [
   },
 
   {
+    plugins: {
+      vuetify: pluginVuetify,
+    },
     rules: {
       "vuetify/no-deprecated-components": "error",
       "vuetify/no-deprecated-props": "error",

--- a/package.json
+++ b/package.json
@@ -1,38 +1,40 @@
 {
-    "name": "website-vue",
-    "private": true,
-    "type": "module",
-    "version": "0.0.0",
-    "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "preview": "vite preview",
-        "lint": "eslint . --fix"
-    },
-    "dependencies": {
-        "@fontsource/roboto": "5.2.10",
-        "@mdi/font": "7.4.47",
-        "pinia": "^3.0.4",
-        "vue": "^3.5.34",
-        "vuetify": "^4.0.7"
-    },
-    "devDependencies": {
-        "@fortawesome/fontawesome-free": "^7.2.0",
-        "@mdi/js": "^7.4.47",
-        "@vitejs/plugin-vue": "^6.0.6",
-        "eslint": "^10.3.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-config-vuetify": "^4.6.2",
-        "eslint-plugin-prettier": "^5.5.5",
-        "eslint-plugin-vuetify": "^2.7.2",
-        "prettier": "^3.8.3",
-        "sass-embedded": "^1.99.0",
-        "unplugin-auto-import": "^21.0.0",
-        "unplugin-vue-components": "^32.0.0",
-        "vite": "^8.0.11",
-        "vite-plugin-vue-layouts-next": "^2.1.0",
-        "vite-plugin-vuetify": "^2.1.3",
-        "vue-router": "^5.0.6"
-    },
-    "packageManager": "pnpm@10.33.0"
+  "name": "website-vue",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --fix"
+  },
+  "dependencies": {
+    "@fontsource/roboto": "5.2.10",
+    "@mdi/font": "7.4.47",
+    "pinia": "^3.0.4",
+    "vue": "^3.5.34",
+    "vuetify": "^4.0.7"
+  },
+  "devDependencies": {
+    "@fortawesome/fontawesome-free": "^7.2.0",
+    "@mdi/js": "^7.4.47",
+    "@typescript-eslint/parser": "^8.59.4",
+    "@vitejs/plugin-vue": "^6.0.6",
+    "eslint": "^10.3.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-config-vuetify": "^4.6.2",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-vuetify": "^2.7.2",
+    "prettier": "^3.8.3",
+    "sass-embedded": "^1.99.0",
+    "typescript": "^6.0.3",
+    "unplugin-auto-import": "^21.0.0",
+    "unplugin-vue-components": "^32.0.0",
+    "vite": "^8.0.11",
+    "vite-plugin-vue-layouts-next": "^2.1.0",
+    "vite-plugin-vuetify": "^2.1.3",
+    "vue-router": "^5.0.6"
+  },
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@mdi/js':
         specifier: ^7.4.47
         version: 7.4.47
+      '@typescript-eslint/parser':
+        specifier: ^8.59.4
+        version: 8.59.4(eslint@10.3.0)(typescript@6.0.3)
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
         version: 6.0.6(vite@8.0.11(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
@@ -47,13 +50,16 @@ importers:
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.3.0))(eslint@10.3.0)(prettier@3.8.3)
       eslint-plugin-vuetify:
         specifier: ^2.7.2
-        version: 2.7.2(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))(vuetify@4.0.7)
+        version: 2.7.2(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.4(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))(vuetify@4.0.7)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
       sass-embedded:
         specifier: ^1.99.0
         version: 1.99.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
       unplugin-auto-import:
         specifier: ^21.0.0
         version: 21.0.0
@@ -478,8 +484,21 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/project-service@8.59.2':
     resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -488,8 +507,18 @@ packages:
     resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.59.2':
     resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -505,8 +534,18 @@ packages:
     resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.59.2':
     resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -520,6 +559,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.59.2':
     resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-vue@6.0.6':
@@ -2188,10 +2231,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.59.4(eslint@10.3.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      eslint: 10.3.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.59.2(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2202,7 +2266,16 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
 
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
   '@typescript-eslint/tsconfig-utils@8.59.2(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -2220,12 +2293,29 @@ snapshots:
 
   '@typescript-eslint/types@8.59.2': {}
 
+  '@typescript-eslint/types@8.59.4': {}
+
   '@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.0
@@ -2249,6 +2339,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.59.2':
     dependencies:
       '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-vue@6.0.6(vite@8.0.11(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))':
@@ -2506,7 +2601,7 @@ snapshots:
       '@eslint/eslintrc': 3.3.5
       '@eslint/js': 10.0.1(eslint@10.3.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.3.0)
-      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@10.3.0)(typescript@6.0.3)
       eslint: 10.3.0
       eslint-config-flat-gitignore: 2.3.0(eslint@10.3.0)
       eslint-flat-config-utils: 3.2.0
@@ -2517,7 +2612,7 @@ snapshots:
       eslint-plugin-pnpm: 1.6.0(eslint@10.3.0)
       eslint-plugin-regexp: 3.1.0(eslint@10.3.0)
       eslint-plugin-unicorn: 64.0.0(eslint@10.3.0)
-      eslint-plugin-vue: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))
+      eslint-plugin-vue: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.4(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))
       eslint-typegen: 2.3.1(eslint@10.3.0)
       exsolve: 1.0.8
       globals: 17.6.0
@@ -2629,7 +2724,7 @@ snapshots:
       semver: 7.8.0
       strip-indent: 4.1.1
 
-  eslint-plugin-vue@10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0)):
+  eslint-plugin-vue@10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.4(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
       eslint: 10.3.0
@@ -2641,12 +2736,12 @@ snapshots:
       xml-name-validator: 4.0.0
     optionalDependencies:
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.3.0)
-      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@10.3.0)(typescript@6.0.3)
 
-  eslint-plugin-vuetify@2.7.2(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))(vuetify@4.0.7):
+  eslint-plugin-vuetify@2.7.2(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.4(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))(vuetify@4.0.7):
     dependencies:
       eslint: 10.3.0
-      eslint-plugin-vue: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))
+      eslint-plugin-vue: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.3.0))(@typescript-eslint/parser@8.59.4(eslint@10.3.0)(typescript@6.0.3))(eslint@10.3.0)(vue-eslint-parser@10.4.0(eslint@10.3.0))
       requireindex: 1.2.0
       vuetify: 4.0.7(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@6.0.3))
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
 allowBuilds:
-  '3': true
+  "3": true
   '"': true
-  '@parcel/watcher': true
-  '[': true
-  ']': true
+  "@parcel/watcher": true
+  "[": true
+  "]": true
   e: true
   i: true
   l: true

--- a/src/components/AppFeatures.vue
+++ b/src/components/AppFeatures.vue
@@ -11,10 +11,12 @@
         <v-list-item variant="text">
           <v-list-item-title>
             <v-avatar class="mb-2 bg-primary" :icon="item.icon" />
+
             <p class="text-body-medium font-weight-bold text-truncate pb-1">
               {{ item.title }}
             </p>
           </v-list-item-title>
+
           <v-divider
             class="mx-auto mt-1 mb-4"
             inset
@@ -22,6 +24,7 @@
             opacity="1"
             thickness="4"
           ></v-divider>
+
           <v-list-item-subtitle>
             {{ item.subtitle }}
           </v-list-item-subtitle>
@@ -31,7 +34,7 @@
   </v-container>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import {
   mdiConsole,
   mdiDomain,

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -10,6 +10,7 @@
           © {{ new Date().getFullYear() }} Zyner. All rights reserved.
         </p>
       </v-col>
+
       <v-col class="d-flex justify-center justify-md-end" cols="12" sm="6">
         <v-btn
           v-for="(social, i) in socials"
@@ -25,7 +26,7 @@
   </v-footer>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import {
   mdiDocker,
   mdiEmail,

--- a/src/components/AppHero.vue
+++ b/src/components/AppHero.vue
@@ -11,6 +11,7 @@
           >
             <template #append></template>
           </v-chip>
+
           <p class="text-headline-large text-md-h3 font-weight-bold mb-6">
             Digital labbmiljö till ett fast medlemspris
           </p>
@@ -44,6 +45,7 @@
           </div>
         </v-responsive>
       </v-col>
+
       <v-col class="hidden-sm-and-down pa-0" md="6" rols="12">
         <v-responsive>
           <v-img
@@ -58,5 +60,5 @@
 </template>
 
 <script setup lang="ts">
-import { mdiChevronRight, mdiDomain, mdiAccountPlus } from "@mdi/js";
+import { mdiAccountPlus, mdiDomain } from "@mdi/js";
 </script>

--- a/src/components/AppNavigation.vue
+++ b/src/components/AppNavigation.vue
@@ -13,11 +13,12 @@
     </v-list>
   </v-navigation-drawer>
 
-  <v-app-bar absolute app class="px-md-4">
+  <v-app-bar absolute class="px-md-4">
     <v-app-bar-nav-icon
       v-if="$vuetify.display.smAndDown"
       @click="drawer = !drawer"
     />
+
     <v-img
       alt="Zyner logo"
       class="me-sm-8"
@@ -47,14 +48,13 @@
   </v-app-bar>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import {
   mdiFileDocument,
   mdiFormatListText,
   mdiHome,
   mdiWeatherNight,
   mdiWeatherSunny,
-  mdiAccountPlus,
 } from "@mdi/js";
 import { shallowRef } from "vue";
 import { useTheme } from "vuetify";

--- a/src/components/AppPartners.vue
+++ b/src/components/AppPartners.vue
@@ -8,6 +8,7 @@
               <v-img :alt="`${partner.title} logo`" :src="partner.icon" />
             </v-avatar>
           </template>
+
           <template #title>
             <span class="text-body-large font-weight-bold text-truncate">
               {{ partner.title }}

--- a/src/components/AppSection.vue
+++ b/src/components/AppSection.vue
@@ -1,9 +1,14 @@
 <template>
   <v-container>
     <v-responsive class="text-center mx-auto" max-width="600">
-      <p v-if="caption" class="mt-8 text-label-medium text-uppercase">{{ caption }}</p>
+      <p v-if="caption" class="mt-8 text-label-medium text-uppercase">
+        {{ caption }}
+      </p>
 
-      <p v-if="title" class="font-weight-bold text-headline-large">{{ title }}</p>
+      <p v-if="title" class="font-weight-bold text-headline-large">
+        {{ title }}
+      </p>
+
       <p
         v-if="subtitle"
         class="mt-2 text-body-large text-medium-emphasis hidden-sm-and-down"
@@ -14,7 +19,7 @@
   </v-container>
 </template>
 
-<script setup>
+<script setup lang="ts">
 defineProps({
   caption: String,
   title: String,

--- a/src/components/AppTeam.vue
+++ b/src/components/AppTeam.vue
@@ -4,19 +4,21 @@
       <v-col v-for="(member, index) in members" :key="index" cols="auto">
         <v-card width="310px">
           <v-img
+            :alt="member.name"
             aspect-ratio="1"
             class="bg-surface-variant"
             cover
             :src="getAvatarSrc(member.avatar)"
-            :alt="member.name"
           />
 
           <v-card-title>
             {{ member.name }}
           </v-card-title>
+
           <v-card-subtitle>
             {{ getMemberTeamRoleNames(member.id)[0] }}
           </v-card-subtitle>
+
           <v-card-actions>
             <v-btn
               v-for="(link, li) in member.links.slice(0, 3)"
@@ -28,7 +30,9 @@
               target="_blank"
               variant="flat"
             />
+
             <v-spacer />
+
             <v-chip :prepend-icon="mdiAt" size="small" variant="flat">
               {{ member.id }}
             </v-chip>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -33,7 +33,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-import { getWebConfig, type User, type WebConfig } from "@/config";
+import { getWebConfig, type WebConfig } from "@/config";
 
 const defaultConfig: WebConfig = {
   partners: [],

--- a/src/pages/timeline.vue
+++ b/src/pages/timeline.vue
@@ -20,7 +20,7 @@
   </v-container>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { mdiDomain, mdiFileSign, mdiPhone } from "@mdi/js";
 import { useDate } from "vuetify";
 


### PR DESCRIPTION
Fixes the ESLint setup so the configured Vuetify and TypeScript-related rules can run correctly, then applies the resulting lint fixes across the existing Vue components.

This includes wiring the Vuetify plugin rule config, adding the TypeScript parser dependency, adding missing `lang="ts"` attributes, removing unused imports, and applying formatter/lint cleanup.